### PR TITLE
Add support for New Code Search and Code View

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -17,10 +17,10 @@ var /**
         'Anonymous Pro': 'https://fonts.googleapis.com/css2?family=Anonymous+Pro:ital,wght@0,400;0,700;1,400;1,700&display=swap',
         'IBM Plex Mono':
             'https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&display=swap',
-        'Atma':'https://fonts.googleapis.com/css2?family=Atma:wght@300;400;500;600;700&display=swap',
+        Atma: 'https://fonts.googleapis.com/css2?family=Atma:wght@300;400;500;600;700&display=swap',
     },
     selectors = {
-        code: '.blob-code-inner',
+        code: '.blob-code-inner, .react-code-text',
         intentGuides: '[data-rgh-whitespace="space"]',
     };
 


### PR DESCRIPTION
# Description

This PR adds support for the [New Code Search and Code View](https://docs.github.com/en/repositories/working-with-files/managing-files/navigating-files-with-the-new-code-view) beta feature.

The new code view uses the `.react-code-text` CSS selector to apply `font-family` styles instead of the old `.blob-code-inner` selector.

Here's the result:

![image](https://user-images.githubusercontent.com/57580593/221759754-9a398b28-a741-4ce2-8c4f-16ad9ce03b4c.png)
